### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # eip55
 
-[![build status](https://secure.travis-ci.org/dcousens/eip55.png)](http://travis-ci.org/dcousens/eip55)
-[![Version](http://img.shields.io/npm/v/eip55.svg)](https://www.npmjs.org/package/eip55)
+[![build status](https://secure.travis-ci.org/cryptocoinjs/eip55.png)](https://travis-ci.org/cryptocoinjs/eip55)
+[![Version](https://img.shields.io/npm/v/eip55.svg)](https://www.npmjs.org/package/eip55)
 
 An [EIP55](https://github.com/ethereum/EIPs/blob/f3a591f6718035ba358d6a479cadabe313f6ed36/EIPS/eip-55.md) compatible address encoding library.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eip55",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "A EIP55 compatible address encoding library",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,17 @@
     "unit": "tape test/*.js"
   },
   "author": "Daniel Cousens",
+  "contributors": [
+    "Jonathan Underwood <junderwood@bitcoinbank.co.jp>"
+  ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/dcousens/eip55.git"
+    "url": "https://github.com/cryptocoinjs/eip55.git"
   },
+  "files": [
+    "index.js",
+    "index.d.ts"
+  ],
   "keywords": [
     "EIP55",
     "ethereum",
@@ -23,7 +30,7 @@
     "encode",
     "verify"
   ],
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "keccak": "^1.3.0"
   },


### PR DESCRIPTION
# Repository Changes

* Changed from ISC to MIT license (Daniel)
* Added more tests for 100% coverage (Jonathan)

# Interface Changes

* (non-breaking) Added `allowOneCase` boolean (optional) to verify
  * passing true for this argument will include single-case (all lower or all upper) addresses (0x followed by 40 single-case hex characters) into the possibility space that returns true.
  * passing false (default), single case addresses will only return true if the EIP55 hash resulted in all `a-f` being a single case

# Bug Fixes

* encode was allowing any string as long as it was 42 length. so 42 z characters would be encoded into an EIP55-ish z address. Also, you could enter 42 hex characters and the hash would be based on the 42 characters but the output address would only be based on the first 40 characters (thus creating an invalid EIP-55 address that looks like a real address)
  * Now encode will accept 40 hex characters with or without prepended 0x, and properly encode in EIP-55.
  * It will throw Bad address if the input has non-hex symbols or is the improper length, or is not a string.
  * **This is possibly breaking**... but it only breaks apps that rely on it encoding un-encodable (z etc.) addresses.
  * **Therefore, I propose this be published as a patch**